### PR TITLE
`Swarm.Receive` uses callback to handle message

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The core abstraction is the `Swarm`. Which represents a group of nodes which can
 ```
 type Swarm interface {
     Tell(ctx context.Context, dst Addr, data []byte) error
-    Receive(ctx context.Context, src, dst, *Addr, buf []byte) (int, error)
+    Receive(ctx context.Context, fn func(Message)) error
 
     ParseAddr(data []byte) (Addr, error)
     LocalAddrs() []Addr

--- a/cmd/p2putil/main.go
+++ b/cmd/p2putil/main.go
@@ -47,17 +47,16 @@ var testConnectCmd = &cobra.Command{
 
 		go func() error {
 			ctx := context.TODO()
-			buf := make([]byte, s3.MaxIncomingSize())
+			var msg p2p.Message
 			for {
-				var src, dst p2p.Addr
-				n, err := s3.Receive(ctx, &src, &dst, buf)
-				if err != nil {
+				if err := p2p.Receive(ctx, s3, &msg); err != nil {
 					return err
 				}
-				if err := s3.Tell(ctx, src, p2p.IOVec{buf[:n]}); err != nil {
+				src, dst := msg.Src, msg.Dst
+				if err := s3.Tell(ctx, src, p2p.IOVec{msg.Payload}); err != nil {
 					return err
 				}
-				log.Println("MSG:", src, "->", dst, " ", buf[:n])
+				log.Printf("MSG: %v -> %v : %q", src, dst, msg.Payload)
 			}
 		}()
 
@@ -71,6 +70,5 @@ var testConnectCmd = &cobra.Command{
 			}
 			time.Sleep(time.Second)
 		}
-		return nil
 	},
 }

--- a/p/p2pmux/mux_test.go
+++ b/p/p2pmux/mux_test.go
@@ -28,23 +28,19 @@ func TestStringMux(t *testing.T) {
 	var recvFoo, recvBar string
 	eg := errgroup.Group{}
 	eg.Go(func() error {
-		buf := make([]byte, m1foo.MaxIncomingSize())
-		var src, dst p2p.Addr
-		n, err := m1foo.Receive(ctx, &src, &dst, buf)
-		if err != nil {
+		var msg p2p.Message
+		if err := p2p.Receive(ctx, m1foo, &msg); err != nil {
 			return err
 		}
-		recvFoo = string(buf[:n])
+		recvFoo = string(msg.Payload)
 		return nil
 	})
 	eg.Go(func() error {
-		buf := make([]byte, m1bar.MaxIncomingSize())
-		var src, dst p2p.Addr
-		n, err := m1bar.Receive(ctx, &src, &dst, buf)
-		if err != nil {
+		var msg p2p.Message
+		if err := p2p.Receive(ctx, m1bar, &msg); err != nil {
 			return err
 		}
-		recvBar = string(buf[:n])
+		recvBar = string(msg.Payload)
 		return nil
 	})
 
@@ -76,23 +72,19 @@ func TestVarintMux(t *testing.T) {
 	var recvFoo, recvBar string
 	eg := errgroup.Group{}
 	eg.Go(func() error {
-		buf := make([]byte, m1foo.MaxIncomingSize())
-		var src, dst p2p.Addr
-		n, err := m1foo.Receive(ctx, &src, &dst, buf)
-		if err != nil {
+		var msg p2p.Message
+		if err := p2p.Receive(ctx, m1foo, &msg); err != nil {
 			return err
 		}
-		recvFoo = string(buf[:n])
+		recvFoo = string(msg.Payload)
 		return nil
 	})
 	eg.Go(func() error {
-		buf := make([]byte, m1bar.MaxIncomingSize())
-		var src, dst p2p.Addr
-		n, err := m1bar.Receive(ctx, &src, &dst, buf)
-		if err != nil {
+		var msg p2p.Message
+		if err := p2p.Receive(ctx, m1bar, &msg); err != nil {
 			return err
 		}
-		recvBar = string(buf[:n])
+		recvBar = string(msg.Payload)
 		return nil
 	})
 

--- a/p2pconn/packetconn.go
+++ b/p2pconn/packetconn.go
@@ -39,12 +39,12 @@ func (c *packetConn) WriteTo(p []byte, to net.Addr) (int, error) {
 func (c *packetConn) ReadFrom(p []byte) (n int, from net.Addr, err error) {
 	ctx, cf := c.getReadContext()
 	defer cf()
-	var src, dst p2p.Addr
-	n, err = c.swarm.Receive(ctx, &src, &dst, p)
-	if err != nil {
+	if err := c.swarm.Receive(ctx, func(m p2p.Message) {
+		from = Addr{Swarm: c.swarm, Addr: m.Src}
+		n = copy(p, m.Payload)
+	}); err != nil {
 		return 0, nil, err
 	}
-	from = Addr{Swarm: c.swarm, Addr: src}
 	return n, from, nil
 }
 

--- a/s/fragswarm/fragswarm_test.go
+++ b/s/fragswarm/fragswarm_test.go
@@ -30,15 +30,13 @@ func TestFragment(t *testing.T) {
 	a := New(r.NewSwarm(), mtu)
 	b := New(r.NewSwarm(), mtu)
 
-	buf := make([]byte, b.MaxIncomingSize())
+	var recv p2p.Message
 	done := make(chan struct{})
 	go func() error {
 		defer close(done)
-		var msg p2p.Message
-		if err := p2p.Receive(ctx, b, &msg); err != nil {
+		if err := p2p.Receive(ctx, b, &recv); err != nil {
 			return err
 		}
-		buf = msg.Payload
 		return nil
 	}()
 
@@ -48,5 +46,5 @@ func TestFragment(t *testing.T) {
 	}
 	require.NoError(t, a.Tell(ctx, b.LocalAddrs()[0], p2p.IOVec{send}))
 	<-done
-	require.Equal(t, send, buf)
+	require.Equal(t, send, recv.Payload)
 }

--- a/s/fragswarm/fragswarm_test.go
+++ b/s/fragswarm/fragswarm_test.go
@@ -34,12 +34,11 @@ func TestFragment(t *testing.T) {
 	done := make(chan struct{})
 	go func() error {
 		defer close(done)
-		var src, dst p2p.Addr
-		n, err := b.Receive(ctx, &src, &dst, buf)
-		if err != nil {
+		var msg p2p.Message
+		if err := p2p.Receive(ctx, b, &msg); err != nil {
 			return err
 		}
-		buf = buf[:n]
+		buf = msg.Payload
 		return nil
 	}()
 

--- a/s/mapswarm/mapswarm.go
+++ b/s/mapswarm/mapswarm.go
@@ -36,15 +36,14 @@ func (s *swarm) Tell(ctx context.Context, dst p2p.Addr, data p2p.IOVec) error {
 	return s.Swarm.Tell(ctx, s.downward(dst), data)
 }
 
-func (s *swarm) Receive(ctx context.Context, src, dst *p2p.Addr, buf []byte) (int, error) {
-	var src2, dst2 p2p.Addr
-	n, err := s.Swarm.Receive(ctx, &src2, &dst2, buf)
-	if err != nil {
-		return 0, err
-	}
-	*src = s.upward(src2)
-	*dst = s.upward(dst2)
-	return n, nil
+func (s *swarm) Receive(ctx context.Context, th p2p.TellHandler) error {
+	return s.Swarm.Receive(ctx, func(m p2p.Message) {
+		th(p2p.Message{
+			Src:     s.upward(m.Src),
+			Dst:     s.upward(m.Dst),
+			Payload: m.Payload,
+		})
+	})
 }
 
 func (s *swarm) LocalAddrs() []p2p.Addr {

--- a/s/memswarm/memswarm.go
+++ b/s/memswarm/memswarm.go
@@ -19,12 +19,13 @@ import (
 )
 
 type Realm struct {
-	clock    clockwork.Clock
-	latency  time.Duration
-	dropRate float64
-	log      *logrus.Logger
-	logw     io.Writer
-	mtu      int
+	clock         clockwork.Clock
+	latency       time.Duration
+	dropRate      float64
+	log           *logrus.Logger
+	logw          io.Writer
+	mtu           int
+	bufferedTells int
 
 	mu     sync.RWMutex
 	n      int
@@ -33,11 +34,12 @@ type Realm struct {
 
 func NewRealm(opts ...Option) *Realm {
 	r := &Realm{
-		clock:  clockwork.NewRealClock(),
-		log:    logrus.StandardLogger(),
-		logw:   ioutil.Discard,
-		mtu:    1 << 20,
-		swarms: make(map[int]*Swarm),
+		clock:         clockwork.NewRealClock(),
+		log:           logrus.StandardLogger(),
+		logw:          ioutil.Discard,
+		mtu:           1 << 20,
+		swarms:        make(map[int]*Swarm),
+		bufferedTells: 1,
 	}
 	for _, opt := range opts {
 		opt(r)
@@ -79,7 +81,7 @@ func (r *Realm) NewSwarmWithKey(privateKey p2p.PrivateKey) *Swarm {
 		n:          n,
 		privateKey: privateKey,
 
-		tells: swarmutil.NewTellHub(),
+		tells: make(chan p2p.Message, r.bufferedTells),
 		asks:  swarmutil.NewAskHub(),
 	}
 	r.swarms[n] = s
@@ -105,7 +107,7 @@ type Swarm struct {
 	n          int
 	privateKey p2p.PrivateKey
 
-	tells *swarmutil.TellHub
+	tells chan p2p.Message
 	asks  *swarmutil.AskHub
 
 	mu       sync.RWMutex
@@ -164,14 +166,23 @@ func (s *Swarm) Tell(ctx context.Context, addr p2p.Addr, data p2p.IOVec) error {
 	}
 	ctx, cf := context.WithTimeout(ctx, 3*time.Second)
 	defer cf()
-	if err := s2.tells.Deliver(ctx, msg); err != nil && !p2p.IsErrClosed(err) {
-		s.r.log.Warnf("memswarm delivering tell %v -> %v: %v", s.n, a.N, err)
+	select {
+	case <-ctx.Done():
+		s.r.log.Warnf("memswarm delivering tell %v -> %v: %v", s.n, a.N, ctx.Err())
+		return nil
+	case s2.tells <- msg:
+		return nil
 	}
-	return nil
 }
 
-func (s *Swarm) Receive(ctx context.Context, src, dst *p2p.Addr, buf []byte) (int, error) {
-	return s.tells.Receive(ctx, src, dst, buf)
+func (s *Swarm) Receive(ctx context.Context, th p2p.TellHandler) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case msg := <-s.tells:
+		th(msg)
+		return nil
+	}
 }
 
 func (s *Swarm) ServeAsk(ctx context.Context, fn p2p.AskHandler) error {
@@ -198,7 +209,6 @@ func (s *Swarm) Close() error {
 	s.mu.Unlock()
 	s.r.removeSwarm(s)
 	s.asks.CloseWithError(p2p.ErrClosed)
-	s.tells.CloseWithError(p2p.ErrClosed)
 	return nil
 }
 

--- a/s/memswarm/memswarm.go
+++ b/s/memswarm/memswarm.go
@@ -39,7 +39,7 @@ func NewRealm(opts ...Option) *Realm {
 		logw:          ioutil.Discard,
 		mtu:           1 << 20,
 		swarms:        make(map[int]*Swarm),
-		bufferedTells: 1,
+		bufferedTells: 0,
 	}
 	for _, opt := range opts {
 		opt(r)

--- a/s/memswarm/option.go
+++ b/s/memswarm/option.go
@@ -50,6 +50,9 @@ func WithMTU(x int) Option {
 }
 
 func WithBufferedTells(n int) Option {
+	if n < 0 {
+		panic("n < 0")
+	}
 	return func(r *Realm) {
 		r.bufferedTells = n
 	}

--- a/s/memswarm/option.go
+++ b/s/memswarm/option.go
@@ -48,3 +48,9 @@ func WithMTU(x int) Option {
 		r.mtu = x
 	}
 }
+
+func WithBufferedTells(n int) Option {
+	return func(r *Realm) {
+		r.bufferedTells = n
+	}
+}

--- a/s/quicswarm/quicswarm.go
+++ b/s/quicswarm/quicswarm.go
@@ -104,8 +104,8 @@ func (s *Swarm) Tell(ctx context.Context, addr p2p.Addr, data p2p.IOVec) error {
 	return err
 }
 
-func (s *Swarm) Receive(ctx context.Context, src, dst *p2p.Addr, buf []byte) (int, error) {
-	return s.tells.Receive(ctx, src, dst, buf)
+func (s *Swarm) Receive(ctx context.Context, th p2p.TellHandler) error {
+	return s.tells.Receive(ctx, th)
 }
 
 func (s *Swarm) Ask(ctx context.Context, resp []byte, addr p2p.Addr, data p2p.IOVec) (int, error) {

--- a/s/sshswarm/swarm.go
+++ b/s/sshswarm/swarm.go
@@ -117,8 +117,8 @@ func (s *Swarm) ServeAsk(ctx context.Context, fn p2p.AskHandler) error {
 	return s.askHub.ServeAsk(ctx, fn)
 }
 
-func (s *Swarm) Receive(ctx context.Context, src, dst *p2p.Addr, buf []byte) (int, error) {
-	return s.tellHub.Receive(ctx, src, dst, buf)
+func (s *Swarm) Receive(ctx context.Context, th p2p.TellHandler) error {
+	return s.tellHub.Receive(ctx, th)
 }
 
 func (s *Swarm) Ask(ctx context.Context, resp []byte, addr p2p.Addr, data p2p.IOVec) (int, error) {


### PR DESCRIPTION
Changes the Swarm.Receive signature to `Receive(context.Context, func(Message)) error`, which allows us to avoid copying when going from many sources to a single receiver.  This is useful for the `p2pmux` package.