### PR TITLE
Compiler Bugs Fixed in Go 1.19.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brendoncarroll/go-p2p
 
-go 1.18
+go 1.19
 
 require (
 	github.com/brendoncarroll/go-state v0.0.0-20210627233638-99c825eb7040

--- a/s/p2pkeswarm/addr.go
+++ b/s/p2pkeswarm/addr.go
@@ -9,9 +9,8 @@ import (
 )
 
 type Addr[T p2p.Addr] struct {
-	ID p2p.PeerID
-	// TODO: changing this to type T causes internal compiler errors in Go 1.18
-	Addr p2p.Addr
+	ID   p2p.PeerID
+	Addr T
 }
 
 func (a Addr[T]) String() string {
@@ -35,7 +34,7 @@ func (a Addr[T]) Unwrap() p2p.Addr {
 func (a Addr[T]) Map(fn func(T) T) Addr[T] {
 	return Addr[T]{
 		ID:   a.ID,
-		Addr: fn(a.Addr.(T)),
+		Addr: fn(a.Addr),
 	}
 }
 

--- a/s/p2pkeswarm/swarm.go
+++ b/s/p2pkeswarm/swarm.go
@@ -105,7 +105,7 @@ func (s *Swarm[T]) LookupPublicKey(ctx context.Context, dst Addr[T]) (p2p.Public
 }
 
 func (s *Swarm[T]) MTU(ctx context.Context, target Addr[T]) int {
-	n := s.inner.MTU(ctx, target.Addr.(T)) - Overhead
+	n := s.inner.MTU(ctx, target.Addr) - Overhead
 	return min(n, p2pke.MaxMessageLen)
 }
 
@@ -125,7 +125,7 @@ func (s *Swarm[T]) Close() error {
 // getFullAddr returns a p2pke.Channel which matches the full Addr addr.
 func (s *Swarm[T]) getFullAddr(ctx context.Context, addr Addr[T]) (*p2pke.Channel, error) {
 	for {
-		c := s.store.getOrCreate(s.keyForAddr(addr.Addr.(T)), func() *channelState {
+		c := s.store.getOrCreate(s.keyForAddr(addr.Addr), func() *channelState {
 			return &channelState{
 				CreatedAt: time.Now(),
 				Channel: p2pke.NewChannel(p2pke.ChannelConfig{
@@ -134,7 +134,7 @@ func (s *Swarm[T]) getFullAddr(ctx context.Context, addr Addr[T]) (*p2pke.Channe
 						id := s.fingerprinter(pubKey)
 						return id == addr.ID
 					},
-					Send: s.getSender(addr.Addr.(T)),
+					Send: s.getSender(addr.Addr),
 				}),
 			}
 		})
@@ -145,7 +145,7 @@ func (s *Swarm[T]) getFullAddr(ctx context.Context, addr Addr[T]) (*p2pke.Channe
 		if remoteID == addr.ID {
 			return c.Channel, nil
 		}
-		s.store.deleteMatching(s.keyForAddr(addr.Addr.(T)), func(v *channelState) bool {
+		s.store.deleteMatching(s.keyForAddr(addr.Addr), func(v *channelState) bool {
 			return v.Channel == c.Channel
 		})
 	}

--- a/s/quicswarm/addr.go
+++ b/s/quicswarm/addr.go
@@ -10,9 +10,8 @@ import (
 )
 
 type Addr[T p2p.Addr] struct {
-	ID p2p.PeerID
-	// TODO: changing this to type T causes internal compiler errors in Go 1.18
-	Addr p2p.Addr
+	ID   p2p.PeerID
+	Addr T
 }
 
 func (a Addr[T]) Key() string {
@@ -55,13 +54,13 @@ func (a Addr[T]) GetPeerID() p2p.PeerID {
 }
 
 func (a Addr[T]) Unwrap() T {
-	return a.Addr.(T)
+	return a.Addr
 }
 
 func (a Addr[T]) Map(fn func(T) T) Addr[T] {
 	return Addr[T]{
 		ID:   a.ID,
-		Addr: fn(a.Addr.(T)),
+		Addr: fn(a.Addr),
 	}
 }
 

--- a/s/quicswarm/quicswarm.go
+++ b/s/quicswarm/quicswarm.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"io"
-	"io/ioutil"
 	"net"
 	"strings"
 	"sync"
@@ -216,7 +215,7 @@ func (s *Swarm[T]) withSession(ctx context.Context, dst Addr[T], fn func(sess qu
 		return fn(sess)
 	}
 
-	raddr := p2pconn.NewAddr(s.inner, dst.Addr.(T))
+	raddr := p2pconn.NewAddr(s.inner, dst.Addr)
 	host := ""
 	sess, err := quic.DialContext(ctx, s.pconn, raddr, host, generateClientTLS(s.privKey), generateQUICConfig())
 	if err != nil {
@@ -334,7 +333,7 @@ func (s *Swarm[T]) handleTells(ctx context.Context, sess quic.Connection, srcAdd
 		}
 		go func() {
 			lr := io.LimitReader(stream, int64(s.mtu))
-			data, err := ioutil.ReadAll(lr)
+			data, err := io.ReadAll(lr)
 			if err != nil {
 				s.log.Error(err)
 				return


### PR DESCRIPTION
Previously generics could not be used properly for the higher order addresses in `p2pkeswarm` and `quicswarm` because of a compiler bug in Go versions up until at least 1.19.1.  As of 1.19.3 these bugs appear to be fixed.